### PR TITLE
Added Popup:update_layout on VimResized event

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ use({
     focusable = true,
       zindex = 40,
       position = "50%",
-      relative = "editor",
+      relative = "win",
       size = {
         width = "90%",
         height = "90%",

--- a/lua/lazydocker/view.lua
+++ b/lua/lazydocker/view.lua
@@ -19,8 +19,8 @@ function View:set_listeners()
 		self:close()
 	end)
 
-	self.docker_panel:on("VimResized", function()
-		self.docker_panel:update_layout()
+	self.docker_panel:on({ "VimResized", "WinResized" }, function()
+		self:update()
 	end)
 end
 
@@ -76,6 +76,21 @@ function View:toggle()
 	else
 		self:close("disable_autocmd")
 	end
+end
+
+function View:update()
+	-- exit insert mode to free cursor
+	vim.cmd("stopinsert")
+
+	-- redraw the Nui Popup at the new size
+	self.docker_panel:update_layout()
+	
+	-- move cursor into buffer to reset terminal output position in buffer
+	-- (this is necessary when shrinking)
+	vim.api.nvim_feedkeys("gg", "n", true)
+
+	-- go back into insert mode for lazydocker control
+	vim.cmd("startinsert")
 end
 
 return View

--- a/lua/lazydocker/view.lua
+++ b/lua/lazydocker/view.lua
@@ -20,7 +20,8 @@ function View:set_listeners()
 	end)
 
 	self.docker_panel:on({ "VimResized", "WinResized" }, function()
-		self:update()
+		self.docker_panel:update_layout()
+		vim.api.nvim_win_set_cursor(0, { 1, 0 })
 	end)
 end
 
@@ -76,21 +77,6 @@ function View:toggle()
 	else
 		self:close("disable_autocmd")
 	end
-end
-
-function View:update()
-	-- exit insert mode to free cursor
-	vim.cmd("stopinsert")
-
-	-- redraw the Nui Popup at the new size
-	self.docker_panel:update_layout()
-	
-	-- move cursor into buffer to reset terminal output position in buffer
-	-- (this is necessary when shrinking)
-	vim.api.nvim_feedkeys("gg", "n", true)
-
-	-- go back into insert mode for lazydocker control
-	vim.cmd("startinsert")
 end
 
 return View

--- a/lua/lazydocker/view.lua
+++ b/lua/lazydocker/view.lua
@@ -18,6 +18,10 @@ function View:set_listeners()
 	self.docker_panel:on("BufLeave", function()
 		self:close()
 	end)
+
+	self.docker_panel:on("VimResized", function()
+		self.docker_panel:update_layout()
+	end)
 end
 
 function View:check_requirements()


### PR DESCRIPTION
@crnvl96 I noticed the popup window wasn't resizing when the container window was. Please excuse my assumption that this is something you'll want, it seemed like just an oversight.

I also noticed that the default value for `relative` specified in your readme ('editor') was not the true default value in your config.lua ('win') so I updated the readme to reflect the real value.

I understand I may have uncovered a bug here but I'll leave that decision in your hands. For now the readme is in line with the code.